### PR TITLE
Implemented functionality for issue #1

### DIFF
--- a/js/PageController.js
+++ b/js/PageController.js
@@ -51,6 +51,13 @@ function PageController(){
             _body.append(overlay);
             $(".pg-overlay-close").unbind()
             .click(_enableMainPage);
+            _body.keyup(
+                    function(event) {
+                            if (event.keyCode == 27) {
+                                    page.enableMainPage();
+                            }
+                    }
+            );
 
             if ($("#main_content").find("img").length > 0) {
                     $("#main_content img").on('load', function() {


### PR DESCRIPTION
Hopefully, this pull request will close the issue #1 by implementing a page-wide listener that will close box overlays when the visitor presses the escape key.
